### PR TITLE
Clean FHIR resources before saving

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aidbox-react",
-    "version": "1.10.1",
+    "version": "1.11.0",
     "scripts": {
         "build": "tsc & rollup -c",
         "prebuild": "rimraf lib/* & rimraf dist/*",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export * from './utils/date';
 export * from './utils/error';
 export * from './utils/tests';
 export * from './utils/uuid';
+export * from './utils/fhir';
 
 export * from './hooks/bus';
 export * from './hooks/service';

--- a/src/services/fhir.ts
+++ b/src/services/fhir.ts
@@ -1,5 +1,6 @@
 import { AxiosRequestConfig } from 'axios';
 import { AidboxReference, AidboxResource, ValueSet, Bundle, BundleEntry, id } from 'shared/src/contrib/aidbox';
+import { cleanEmptyValues, removeNullsFromDicts } from 'utils/fhir';
 
 import { isFailure, RemoteDataResult, success, failure } from '../libs/remoteData';
 import { buildQueryParams } from './instance';
@@ -93,17 +94,28 @@ function getInactiveSearchParam(resourceType: string) {
 
 export async function createFHIRResource<R extends AidboxResource>(
     resource: R,
-    searchParams?: SearchParams
+    searchParams?: SearchParams,
+    dropNullsFromDicts = true
 ): Promise<RemoteDataResult<WithId<R>>> {
-    return service(create(resource, searchParams));
+    return service(create(resource, searchParams, dropNullsFromDicts));
 }
 
-export function create<R extends AidboxResource>(resource: R, searchParams?: SearchParams): AxiosRequestConfig {
+export function create<R extends AidboxResource>(
+    resource: R,
+    searchParams?: SearchParams,
+    dropNullsFromDicts = true
+): AxiosRequestConfig {
+    let cleanedResource = resource;
+    if (dropNullsFromDicts) {
+        cleanedResource = removeNullsFromDicts(cleanedResource);
+    }
+    cleanedResource = cleanEmptyValues(cleanedResource);
+
     return {
         method: 'POST',
-        url: `/${resource.resourceType}`,
+        url: `/${cleanedResource.resourceType}`,
         params: searchParams,
-        data: resource,
+        data: cleanedResource,
     };
 }
 
@@ -114,23 +126,33 @@ export async function updateFHIRResource<R extends AidboxResource>(
     return service(update(resource, searchParams));
 }
 
-export function update<R extends AidboxResource>(resource: R, searchParams?: SearchParams): AxiosRequestConfig {
+export function update<R extends AidboxResource>(
+    resource: R,
+    searchParams?: SearchParams,
+    dropNullsFromDicts = true
+): AxiosRequestConfig {
+    let cleanedResource = resource;
+    if (dropNullsFromDicts) {
+        cleanedResource = removeNullsFromDicts(cleanedResource);
+    }
+    cleanedResource = cleanEmptyValues(cleanedResource);
+
     if (searchParams) {
         return {
             method: 'PUT',
-            url: `/${resource.resourceType}`,
-            data: resource,
+            url: `/${cleanedResource.resourceType}`,
+            data: cleanedResource,
             params: searchParams,
         };
     }
 
-    if (resource.id) {
-        const versionId = resource.meta && resource.meta.versionId;
+    if (cleanedResource.id) {
+        const versionId = cleanedResource.meta && cleanedResource.meta.versionId;
 
         return {
             method: 'PUT',
-            url: `/${resource.resourceType}/${resource.id}`,
-            data: resource,
+            url: `/${cleanedResource.resourceType}/${cleanedResource.id}`,
+            data: cleanedResource,
             ...(versionId ? { headers: { 'If-Match': versionId } } : {}),
         };
     }
@@ -236,16 +258,24 @@ export async function findFHIRResource<R extends AidboxResource>(
     }
 }
 
-export async function saveFHIRResource<R extends AidboxResource>(resource: R): Promise<RemoteDataResult<WithId<R>>> {
-    return service(save(resource));
+export async function saveFHIRResource<R extends AidboxResource>(
+    resource: R,
+    dropNullsFromDicts: boolean = true
+): Promise<RemoteDataResult<WithId<R>>> {
+    return service(save(resource, dropNullsFromDicts));
 }
 
-export function save<R extends AidboxResource>(resource: R): AxiosRequestConfig {
+export function save<R extends AidboxResource>(resource: R, dropNullsFromDicts: boolean = true): AxiosRequestConfig {
     const versionId = resource.meta && resource.meta.versionId;
+    let cleanedResource = resource;
+    if (dropNullsFromDicts) {
+        cleanedResource = removeNullsFromDicts(cleanedResource);
+    }
+    cleanedResource = cleanEmptyValues(cleanedResource);
 
     return {
         method: resource.id ? 'PUT' : 'POST',
-        data: resource,
+        data: cleanedResource,
         url: `/${resource.resourceType}${resource.id ? '/' + resource.id : ''}`,
         ...(resource.id && versionId ? { headers: { 'If-Match': versionId } } : {}),
     };
@@ -253,7 +283,8 @@ export function save<R extends AidboxResource>(resource: R): AxiosRequestConfig 
 
 export async function saveFHIRResources<R extends AidboxResource>(
     resources: R[],
-    bundleType: 'transaction' | 'batch'
+    bundleType: 'transaction' | 'batch',
+    dropNullsFromDicts: boolean = true
 ): Promise<RemoteDataResult<Bundle<WithId<R>>>> {
     return service({
         method: 'POST',
@@ -261,14 +292,19 @@ export async function saveFHIRResources<R extends AidboxResource>(
         data: {
             type: bundleType,
             entry: resources.map((resource) => {
-                const versionId = resource.meta && resource.meta.versionId;
+                let cleanedResource = resource;
+                if (dropNullsFromDicts) {
+                    cleanedResource = removeNullsFromDicts(cleanedResource);
+                }
+                cleanedResource = cleanEmptyValues(cleanedResource);
+                const versionId = cleanedResource.meta && cleanedResource.meta.versionId;
 
                 return {
-                    resource,
+                    cleanedResource,
                     request: {
-                        method: resource.id ? 'PUT' : 'POST',
-                        url: `/${resource.resourceType}${resource.id ? '/' + resource.id : ''}`,
-                        ...(resource.id && versionId ? { ifMatch: versionId } : {}),
+                        method: cleanedResource.id ? 'PUT' : 'POST',
+                        url: `/${cleanedResource.resourceType}${cleanedResource.id ? '/' + cleanedResource.id : ''}`,
+                        ...(cleanedResource.id && versionId ? { ifMatch: versionId } : {}),
                     },
                 };
             }),
@@ -395,7 +431,7 @@ export type ResourcesMap<T extends AidboxResource> = {
 export function extractBundleResources<T extends AidboxResource>(bundle: Bundle<T>): ResourcesMap<T> {
     const entriesByResourceType = {} as ResourcesMap<T>;
     const entries = bundle.entry || [];
-    entries.forEach(function(entry) {
+    entries.forEach(function (entry) {
         const type = entry.resource!.resourceType;
         if (!entriesByResourceType[type]) {
             entriesByResourceType[type] = [];

--- a/src/services/fhir.ts
+++ b/src/services/fhir.ts
@@ -1,8 +1,8 @@
 import { AxiosRequestConfig } from 'axios';
 import { AidboxReference, AidboxResource, ValueSet, Bundle, BundleEntry, id } from 'shared/src/contrib/aidbox';
-import { cleanEmptyValues, removeNullsFromDicts } from 'utils/fhir';
 
 import { isFailure, RemoteDataResult, success, failure } from '../libs/remoteData';
+import { cleanEmptyValues, removeNullsFromDicts } from '../utils/fhir';
 import { buildQueryParams } from './instance';
 import { SearchParams } from './search';
 import { service } from './service';
@@ -300,7 +300,7 @@ export async function saveFHIRResources<R extends AidboxResource>(
                 const versionId = cleanedResource.meta && cleanedResource.meta.versionId;
 
                 return {
-                    cleanedResource,
+                    resource: cleanedResource,
                     request: {
                         method: cleanedResource.id ? 'PUT' : 'POST',
                         url: `/${cleanedResource.resourceType}${cleanedResource.id ? '/' + cleanedResource.id : ''}`,

--- a/src/utils/fhir.ts
+++ b/src/utils/fhir.ts
@@ -1,0 +1,54 @@
+function isEmpty(data: any): boolean {
+    if (Array.isArray(data)) {
+        return data.length === 0;
+    }
+
+    if (typeof data === 'object' && data !== null) {
+        return Object.keys(data).length === 0;
+    }
+
+    return false;
+}
+
+export function cleanEmptyValues(data: any): any {
+    if (Array.isArray(data)) {
+        return data.map((item) => {
+            return isEmpty(item) ? null : cleanEmptyValues(item);
+        });
+    }
+
+    if (typeof data === 'object' && data !== null) {
+        const cleaned: Record<string, any> = {};
+        for (const [key, value] of Object.entries(data)) {
+            const cleanedValue = cleanEmptyValues(value);
+            if (!isEmpty(cleanedValue)) {
+                cleaned[key] = cleanedValue;
+            }
+        }
+        return cleaned;
+    }
+
+    return data;
+}
+
+function isNull(value: any): boolean {
+    return value === null;
+}
+
+export function removeNullsFromDicts(data: any): any {
+    if (Array.isArray(data)) {
+        return data.map(removeNullsFromDicts);
+    }
+
+    if (typeof data === 'object' && data !== null) {
+        const result: Record<string, any> = {};
+        for (const [key, value] of Object.entries(data)) {
+            if (!isNull(value)) {
+                result[key] = removeNullsFromDicts(value);
+            }
+        }
+        return result;
+    }
+
+    return data;
+}

--- a/src/utils/fhir.ts
+++ b/src/utils/fhir.ts
@@ -28,11 +28,15 @@ export function cleanEmptyValues(data: any): any {
         return cleaned;
     }
 
+    if (typeof data === 'undefined') {
+        return null;
+    }
+
     return data;
 }
 
 function isNull(value: any): boolean {
-    return value === null;
+    return value === null || value === undefined;
 }
 
 export function removeNullsFromDicts(data: any): any {
@@ -48,6 +52,10 @@ export function removeNullsFromDicts(data: any): any {
             }
         }
         return result;
+    }
+
+    if (typeof data === 'undefined') {
+        return null;
     }
 
     return data;

--- a/tests/utils/fhir.spec.ts
+++ b/tests/utils/fhir.spec.ts
@@ -1,0 +1,39 @@
+import { cleanEmptyValues, removeNullsFromDicts } from '../../src/utils/fhir';
+
+describe('cleanEmptyValues', () => {
+    it('cleans empty values from dictionaries and arrays recursively', () => {
+        expect(cleanEmptyValues({})).toEqual({});
+        expect(cleanEmptyValues({ str: '' })).toEqual({ str: '' });
+
+        expect(cleanEmptyValues({ nested: { nested2: [{}] } })).toEqual({
+            nested: { nested2: [null] },
+        });
+
+        expect(cleanEmptyValues({ nested: { nested2: {} } })).toEqual({});
+
+        expect(cleanEmptyValues({ item: [] })).toEqual({});
+        expect(cleanEmptyValues({ item: [null] })).toEqual({ item: [null] });
+
+        expect(cleanEmptyValues({ item: [null, { item: null }] })).toEqual({
+            item: [null, { item: null }],
+        });
+
+        expect(cleanEmptyValues({ item: [null, { item: null }, {}] })).toEqual({
+            item: [null, { item: null }, null],
+        });
+    });
+});
+
+describe('removeNullsFromDicts', () => {
+    it('removes nulls from nested dictionaries but not from arrays', () => {
+        expect(removeNullsFromDicts({})).toEqual({});
+        expect(removeNullsFromDicts({ item: [] })).toEqual({ item: [] });
+        expect(removeNullsFromDicts({ item: [null] })).toEqual({ item: [null] });
+        expect(removeNullsFromDicts({ item: [null, { item: null }] })).toEqual({
+            item: [null, {}],
+        });
+        expect(removeNullsFromDicts({ item: [null, { item: null }, {}] })).toEqual({
+            item: [null, {}, {}],
+        });
+    });
+});

--- a/tests/utils/fhir.spec.ts
+++ b/tests/utils/fhir.spec.ts
@@ -1,7 +1,7 @@
 import { cleanEmptyValues, removeNullsFromDicts } from '../../src/utils/fhir';
 
 describe('cleanEmptyValues', () => {
-    it('cleans empty values from dictionaries and arrays recursively', () => {
+    it('cleans null values from dictionaries and arrays recursively', () => {
         expect(cleanEmptyValues({})).toEqual({});
         expect(cleanEmptyValues({ str: '' })).toEqual({ str: '' });
 
@@ -22,6 +22,28 @@ describe('cleanEmptyValues', () => {
             item: [null, { item: null }, null],
         });
     });
+
+    it('cleans undefined values from dictionaries and arrays recursively', () => {
+        expect(cleanEmptyValues({})).toEqual({});
+        expect(cleanEmptyValues({ str: '' })).toEqual({ str: '' });
+
+        expect(cleanEmptyValues({ nested: { nested2: [{}] } })).toEqual({
+            nested: { nested2: [null] },
+        });
+
+        expect(cleanEmptyValues({ nested: { nested2: {} } })).toEqual({});
+
+        expect(cleanEmptyValues({ item: [] })).toEqual({});
+        expect(cleanEmptyValues({ item: [undefined] })).toEqual({ item: [null] });
+
+        expect(cleanEmptyValues({ item: [undefined, { item: undefined }] })).toEqual({
+            item: [null, { item: null }],
+        });
+
+        expect(cleanEmptyValues({ item: [undefined, { item: undefined }, {}] })).toEqual({
+            item: [null, { item: null }, null],
+        });
+    });
 });
 
 describe('removeNullsFromDicts', () => {
@@ -30,6 +52,18 @@ describe('removeNullsFromDicts', () => {
         expect(removeNullsFromDicts({ item: [] })).toEqual({ item: [] });
         expect(removeNullsFromDicts({ item: [null] })).toEqual({ item: [null] });
         expect(removeNullsFromDicts({ item: [null, { item: null }] })).toEqual({
+            item: [null, {}],
+        });
+        expect(removeNullsFromDicts({ item: [null, { item: null }, {}] })).toEqual({
+            item: [null, {}, {}],
+        });
+    });
+
+    it('removes undefined from nested dictionaries but not from arrays', () => {
+        expect(removeNullsFromDicts({})).toEqual({});
+        expect(removeNullsFromDicts({ item: [] })).toEqual({ item: [] });
+        expect(removeNullsFromDicts({ item: [undefined] })).toEqual({ item: [null] });
+        expect(removeNullsFromDicts({ item: [undefined, { item: undefined }] })).toEqual({
             item: [null, {}],
         });
         expect(removeNullsFromDicts({ item: [null, { item: null }, {}] })).toEqual({

--- a/tests/utils/fhir.spec.ts
+++ b/tests/utils/fhir.spec.ts
@@ -71,3 +71,8 @@ describe('removeNullsFromDicts', () => {
         });
     });
 });
+
+describe('combine two cleaning functions', () => {
+    const data = { item: [undefined, { item: undefined }, {}] };
+    expect(cleanEmptyValues(removeNullsFromDicts(data))).toEqual({ item: [null, null, null] });
+});


### PR DESCRIPTION
According to FHIR specification fields with empty values are not allowed except of `null` values in arrays